### PR TITLE
Fix typo in README example code

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -23,7 +23,7 @@ Creating a new provider will create a new collection called `guilds` in your dat
 - The index is so that we can query based on the guilds id do not have to store the id given by FaunaDB.
 
 ```js
-const { Client } = requrie('faunadb');
+const { Client } = require('faunadb');
 const FaunaProvider = require('commando-provider-faunadb');
 
 ...


### PR DESCRIPTION
No idea why it says I changed line 41, I didn't touch that line ¯\_(ツ)_/¯